### PR TITLE
Pin jupyter version in html publisher action

### DIFF
--- a/.github/workflows/html_publisher.yaml
+++ b/.github/workflows/html_publisher.yaml
@@ -16,7 +16,7 @@ jobs:
       with:
         python-version: 3.9
     - name: Install jupyter
-      run: pip install jupyter
+      run: pip install jupyter==1.0.0
     - name: Convert notebooks
       run: |
         jupyter nbconvert notebooks/database-builds.ipynb --to html --template basic --no-input --output-dir notebooks/html


### PR DESCRIPTION
* matches https://github.com/opensafely/database-notebooks/blob/master/requirements.txt#L45
* avoid some version skew between the action & development environments
* (slightly) reduce the (unlikely) risk of dependency attack - this action has write access to the repo
* alternative options for versioning this include - pip install everything in requirements.txt, etc...